### PR TITLE
Use absolute paths in virtual files for proper matching against patterns

### DIFF
--- a/bin/diff-sniffer
+++ b/bin/diff-sniffer
@@ -17,7 +17,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 try {
     exit(
-        (new Application())->run(new Command(getcwd()), $_SERVER['argv'])
+        (new Application())->run(new Command(), getcwd(), $_SERVER['argv'])
     );
 } catch (Exception $e) {
     fwrite(STDERR, $e->getMessage() . PHP_EOL);

--- a/src/Application.php
+++ b/src/Application.php
@@ -16,7 +16,6 @@ use function assert;
 use function basename;
 use function current;
 use function define;
-use function getcwd;
 use function is_string;
 use function printf;
 
@@ -38,7 +37,7 @@ final class Application
      *
      * @throws Exception
      */
-    public function run(Command $command, array $args): int
+    public function run(Command $command, string $cwd, array $args): int
     {
         $programName = array_shift($args);
         assert(is_string($programName));
@@ -59,15 +58,12 @@ final class Application
         }
 
         try {
-            $changeSet = $command->createChangeSet($args);
+            $changeSet = $command->createChangeSet($cwd, $args);
         } catch (BadUsage $e) {
             $this->printUsage($programName);
 
             return 1;
         }
-
-        $cwd = getcwd();
-        assert(is_string($cwd));
 
         $loader = new ProjectLoader($cwd);
         $loader->registerClassLoader();
@@ -85,7 +81,7 @@ final class Application
             $config = new Config(array_merge($args, ['--no-cache']));
             $runner = new Runner($config);
 
-            return $runner->run($changeSet);
+            return $runner->run($changeSet, $cwd);
         } catch (DeepExitException $e) {
             echo $e->getMessage();
 

--- a/src/Command.php
+++ b/src/Command.php
@@ -14,5 +14,5 @@ interface Command
      *
      * @param array<int,string> $args Command arguments
      */
-    public function createChangeSet(array &$args): Changeset;
+    public function createChangeSet(string $cwd, array &$args): Changeset;
 }

--- a/src/Git/Command.php
+++ b/src/Git/Command.php
@@ -19,18 +19,10 @@ use function substr;
  */
 final class Command implements CommandInterface
 {
-    /** @var string */
-    private $directory;
-
-    public function __construct(string $directory)
-    {
-        $this->directory = $directory;
-    }
-
     /**
      * {@inheritDoc}
      */
-    public function createChangeSet(array &$args): ChangesetInterface
+    public function createChangeSet(string $cwd, array &$args): ChangesetInterface
     {
         $diffArgs = [];
 
@@ -49,6 +41,6 @@ final class Command implements CommandInterface
             $diffArgs[] = $arg;
         }
 
-        return new Changeset(new Cli(), $diffArgs, $this->directory);
+        return new Changeset(new Cli(), $diffArgs, $cwd);
     }
 }

--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -38,15 +38,19 @@ final class Iterator implements IteratorAggregate
     /** @var Ruleset */
     private $ruleSet;
 
+    /** @var string */
+    private $cwd;
+
     /**
      * @param Traversable<int,string> $files
      */
-    public function __construct(Traversable $files, Changeset $changeSet, Ruleset $ruleSet, Config $config)
+    public function __construct(Traversable $files, Changeset $changeSet, Ruleset $ruleSet, Config $config, string $cwd)
     {
         $this->files     = $files;
         $this->changeSet = $changeSet;
         $this->ruleSet   = $ruleSet;
         $this->config    = $config;
+        $this->cwd       = $cwd;
     }
 
     /**
@@ -88,7 +92,7 @@ final class Iterator implements IteratorAggregate
     private function createFile(string $path, string $contents): File
     {
         $file       = new DummyFile($contents, $this->ruleSet, $this->config);
-        $file->path = $path;
+        $file->path = $this->cwd . DIRECTORY_SEPARATOR . $path;
 
         return $file;
     }

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -7,6 +7,7 @@ namespace DiffSniffer;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Reporter as BaseReporter;
+use PHP_CodeSniffer\Util\Common;
 
 /**
  * Wrapper report for PHP_CodeSniffer.
@@ -16,11 +17,15 @@ class Reporter extends BaseReporter
     /** @var Diff */
     private $diff;
 
-    public function __construct(Diff $diff, Config $config)
+    /** @var string */
+    private $cwd;
+
+    public function __construct(Diff $diff, Config $config, string $cwd)
     {
         parent::__construct($config);
 
         $this->diff = $diff;
+        $this->cwd  = $cwd;
     }
 
     /**
@@ -31,7 +36,7 @@ class Reporter extends BaseReporter
     public function prepareFileReport(File $file): array
     {
         return $this->diff->filter(
-            $file->path,
+            Common::stripBasepath($file->getFilename(), $this->cwd),
             parent::prepareFileReport($file)
         );
     }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -31,7 +31,7 @@ class Runner
      * @throws DeepExitException
      * @throws Exception
      */
-    public function run(Changeset $changeset): int
+    public function run(Changeset $changeset, string $cwd): int
     {
         $diff = new Diff($changeset->getDiff());
 
@@ -39,14 +39,14 @@ class Runner
             return 0;
         }
 
-        $reporter = new Reporter($diff, $this->config);
+        $reporter = new Reporter($diff, $this->config, $cwd);
 
         $runner           = new BaseRunner();
         $runner->config   = $this->config;
         $runner->reporter = $reporter;
         $runner->init();
 
-        $it = new Iterator($diff, $changeset, $runner->ruleset, $this->config);
+        $it = new Iterator($diff, $changeset, $runner->ruleset, $this->config, $cwd);
 
         foreach ($it as $file) {
             $runner->processFile($file);

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -24,6 +24,6 @@ class RunnerTest extends TestCase
             ->method('getDiff')
             ->willReturn('');
 
-        $this->assertSame(0, $runner->run($changeSet));
+        $this->assertSame(0, $runner->run($changeSet, __DIR__));
     }
 }

--- a/tests/fixtures/exclude-pattern/tree/phpcs.xml
+++ b/tests/fixtures/exclude-pattern/tree/phpcs.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
-<ruleset>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg name="basepath" value="."/>
     <exclude-pattern>excluded/*</exclude-pattern>
     <rule ref="PSR2"/>
 </ruleset>

--- a/tests/fixtures/excluded-rule-cache/tree/phpcs.xml
+++ b/tests/fixtures/excluded-rule-cache/tree/phpcs.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
-<ruleset>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg name="basepath" value="."/>
     <arg name="cache" value="cache.txt"/>
 
     <rule ref="PSR2">

--- a/tests/fixtures/only-changed-lines-reported/tree/phpcs.xml
+++ b/tests/fixtures/only-changed-lines-reported/tree/phpcs.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
-<ruleset>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../../../../vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg name="basepath" value="."/>
     <rule ref="PSR2"/>
 </ruleset>

--- a/tests/fixtures/rule-exclude-pattern/changeset.diff
+++ b/tests/fixtures/rule-exclude-pattern/changeset.diff
@@ -1,0 +1,9 @@
+diff --git a/main.php b/main.php
+`--- /dev/null
++++ b/main.php
+@@ -0,0 +1,5 @@
++<?php
++
++if ( ! isset($foo)) {
++    $foo = 'bar';
++}

--- a/tests/fixtures/rule-exclude-pattern/tree/main.php
+++ b/tests/fixtures/rule-exclude-pattern/tree/main.php
@@ -1,0 +1,5 @@
+<?php
+
+if ( ! isset($foo)) {
+    $foo = 'bar';
+}

--- a/tests/fixtures/rule-exclude-pattern/tree/phpcs.xml
+++ b/tests/fixtures/rule-exclude-pattern/tree/phpcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <rule ref="PSR2"/>
+    <rule ref="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace">
+        <exclude-pattern>*/main.php</exclude-pattern>
+    </rule>
+</ruleset>


### PR DESCRIPTION
The root cause of the problem is that `Iterator` currently provides relative paths to the changed files. It a known and acceptable behavior for two reasons:

1. The output of `git diff` by definition contains paths relative to the repository root.
2. Seeing short relative paths in the output is more convenient than seeing the absolute ones. At that time I wasn't aware of the `basepath` configuration parameter.

The relative paths don't have a character that would match to the leading `*/` that an absolute path would always have, hence the bug.

The solution is to inject the current working directory into the iterator to make it provide absolute paths. The downside of that the the `Reporter` has to strip the base path from the absolute path in order to be able to match the result against the relative paths that the diff still produces.

The nice outcome of this refactoring is that the `Application` class no longer calls `getcwd()` but only relies on the value provided by the CLI entrypoint.

Fixes #43.